### PR TITLE
Fix non-https repository URLs in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
     </repository>
     <repository>
       <id>bds-artifactory</id>
-      <url>${repoReleaseArtifactoryUrl}</url>
+      <url>https://${repoReleaseArtifactoryUrl}</url>
     </repository>
   </repositories>
   <pluginRepositories>
@@ -213,7 +213,7 @@
       <distributionManagement>
         <snapshotRepository>
           <id>bds-artifactory</id>
-          <url>${snapshotArtifactoryUrl}</url>
+          <url>https://${snapshotArtifactoryUrl}</url>
         </snapshotRepository>
       </distributionManagement>
     </profile>
@@ -225,7 +225,7 @@
       <distributionManagement>
         <repository>
           <id>bds-artifactory</id>
-          <url>${releaseArtifactoryUrl}</url>
+          <url>https://${releaseArtifactoryUrl}</url>
         </repository>
       </distributionManagement>
     </profile>
@@ -237,11 +237,11 @@
       <distributionManagement>
         <repository>
           <id>bds-artifactory</id>
-          <url>${qaArtifactoryUrl}</url>
+          <url>https://${qaArtifactoryUrl}</url>
         </repository>
         <snapshotRepository>
           <id>bds-artifactory</id>
-          <url>${snapshotArtifactoryUrl}</url>
+          <url>https://${snapshotArtifactoryUrl}</url>
         </snapshotRepository>
       </distributionManagement>
     </profile>


### PR DESCRIPTION
Fixes #1

Update `pom.xml` to use HTTPS URLs for repository references.

* Change the repository URL with the `id` `bds-artifactory` to use an HTTPS URL `${repoReleaseArtifactoryUrl}`.
* Change the snapshot repository URL with the `id` `bds-artifactory` in the profile with the `id` `snapshot-deployment` to use an HTTPS URL `${snapshotArtifactoryUrl}`.
* Change the repository URL with the `id` `bds-artifactory` in the profile with the `id` `deployment` to use an HTTPS URL `${releaseArtifactoryUrl}`.
* Change the repository URL with the `id` `bds-artifactory` in the profile with the `id` `qa-deployment` to use an HTTPS URL `${qaArtifactoryUrl}`.
* Change the snapshot repository URL with the `id` `bds-artifactory` in the profile with the `id` `qa-deployment` to use an HTTPS URL `${snapshotArtifactoryUrl}`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gounthar/blackduck-security-scan-plugin/pull/2?shareId=ea54fa6c-6cfd-45c0-be7e-a7d2c60b2a99).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated repository configurations to ensure secure URLs are used for resource management. These internal improvements help maintain reliable and consistent connections while preserving public functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->